### PR TITLE
Fixing robots.txt disallow of /proxy

### DIFF
--- a/www/robots.txt
+++ b/www/robots.txt
@@ -1,0 +1,4 @@
+User-agent: * 
+Disallow: /layouts/
+Disallow: /help/
+Disallow: /proxy

--- a/www/robots.txt
+++ b/www/robots.txt
@@ -1,4 +1,5 @@
 User-agent: * 
 Disallow: /layouts/
 Disallow: /help/
+Disallow: /proxy/
 Disallow: /proxy


### PR DESCRIPTION
This should add and fix robots.txt to `disallow: /proxy` search indexing 