### PR TITLE
regex out Helpxx: in <h1> title </h1>

### DIFF
--- a/src/Model/HelpScreenModel.php
+++ b/src/Model/HelpScreenModel.php
@@ -230,7 +230,7 @@ class HelpScreenModel implements StatefulModelInterface
 	public function getTitle() : string
 	{
 		// Regex out the Prefix Help##:
-		$titlePrefix = "!Help\d\d:!";
+		$titlePrefix = "!.+\d\d:!";
 		$this->title = preg_replace($titlePrefix, '', $this->title);
 		return $this->title;
 	}

--- a/src/Model/HelpScreenModel.php
+++ b/src/Model/HelpScreenModel.php
@@ -338,9 +338,9 @@ class HelpScreenModel implements StatefulModelInterface
 	public function amendPageContent()
 	{	
 		// Remove Help##: from page <h1> tagged page title
-		$pattern = '<h1>Help\S+:';
+		$pattern = '!<h1>Help\S+:!';
 		$replace = '<h1>';
-		$this->page = str_replace($pattern, $replace, $this->page);
+		$this->page = preg_replace($pattern, $replace, $this->page);
 	}
 
 	/**

--- a/src/Model/HelpScreenModel.php
+++ b/src/Model/HelpScreenModel.php
@@ -202,9 +202,6 @@ class HelpScreenModel implements StatefulModelInterface
 
 		// Amend or remove links from wiki page.
 		$this->amendLinks();
-		
-		// Amend or remove specific page content
-		$this->amendPageContent();
 
 		// Remove table of contents.
 		if ($this->getState()->get('remove_toc', false))
@@ -232,7 +229,10 @@ class HelpScreenModel implements StatefulModelInterface
 	 */
 	public function getTitle() : string
 	{
-		return $this->title;
+		// Regex out the Prefix Help##:
+    	$titlePrefix = "!Help\d\d:!";
+		$this->title = preg_replace($titlePrefix, '', $this->title);
+    	return $this->title;
 	}
 
 	/**
@@ -328,19 +328,6 @@ class HelpScreenModel implements StatefulModelInterface
 		$pattern = '<a href="#';
 		$replace = '<a href="' . $this->currentUri->toString() . '#';
 		$this->page = str_replace($pattern, $replace, $this->page);
-	}
-
-	/**
-	 * Amend or remove content from a wiki page.
-	 *
-	 * @return  void
-	 */	
-	public function amendPageContent()
-	{	
-		// Remove Help##: from page <h1> tagged page title
-		$pattern = '!<h1>Help\S+:!';
-		$replace = '<h1>';
-		$this->page = preg_replace($pattern, $replace, $this->page);
 	}
 
 	/**

--- a/src/Model/HelpScreenModel.php
+++ b/src/Model/HelpScreenModel.php
@@ -230,9 +230,9 @@ class HelpScreenModel implements StatefulModelInterface
 	public function getTitle() : string
 	{
 		// Regex out the Prefix Help##:
-    	$titlePrefix = "!Help\d\d:!";
+		$titlePrefix = "!Help\d\d:!";
 		$this->title = preg_replace($titlePrefix, '', $this->title);
-    	return $this->title;
+		return $this->title;
 	}
 
 	/**

--- a/src/Model/HelpScreenModel.php
+++ b/src/Model/HelpScreenModel.php
@@ -202,6 +202,9 @@ class HelpScreenModel implements StatefulModelInterface
 
 		// Amend or remove links from wiki page.
 		$this->amendLinks();
+		
+		// Amend or remove specific page content
+		$this->amendPageContent();
 
 		// Remove table of contents.
 		if ($this->getState()->get('remove_toc', false))
@@ -324,6 +327,19 @@ class HelpScreenModel implements StatefulModelInterface
 		// Replace any anchor based links
 		$pattern = '<a href="#';
 		$replace = '<a href="' . $this->currentUri->toString() . '#';
+		$this->page = str_replace($pattern, $replace, $this->page);
+	}
+
+	/**
+	 * Amend or remove content from a wiki page.
+	 *
+	 * @return  void
+	 */	
+	public function amendPageContent()
+	{	
+		// Remove Help##: from page <h1> tagged page title
+		$pattern = '<h1>Help\S+:';
+		$replace = '<h1>';
 		$this->page = str_replace($pattern, $replace, $this->page);
 	}
 


### PR DESCRIPTION
Didn't test it 😛 but it should work to eliminate Helpxx: Prefix from Title at the top in the `<h1>` tags.

Changes should look like

Current look

### Help38:Start Here

to a stripped out `Help37:` or `Help38:`

### Start Here