### PR TITLE
Add default http security header using .htaccess excluding X-Frame-Options

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -4,6 +4,22 @@
 ##
 
 ###########################################
+# ======= Set basic Security header =======
+
+<IfModule mod_headers.c>
+	# X-XSS-Protection
+	Header always set X-XSS-Protection "1; mode=block"
+	# X-Frame-Options (Here on the help site we don't want to set that header!)
+	# Header always set X-Frame-Options DENY
+	# X-Content-Type nosniff
+	Header always set X-Content-Type-Options nosniff
+	# Referrer Policy
+	Header always set Referrer-Policy "no-referrer-when-downgrade"
+</IfModule>
+
+###########################################
+
+###########################################
 # ======= Enable the Rewrite Engine =======
 
 RewriteEngine On


### PR DESCRIPTION
#### Summary of Changes

With this PR we set the basic http security headers but excluding the X-Frame-Options here.

#### Open points / questions

- [ ] CSP rules (needs to wait until we have a csp-reporter place)