### PR TITLE
Removing Google Tag Manager

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,11 +1,10 @@
-{% from 'macros.html.twig' import full_page_head, google_tag_manager %}
+{% from 'macros.html.twig' import full_page_head %}
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
         {{ full_page_head() }}
     </head>
     <body class="site">
-        {{ google_tag_manager() }}
         {% block nav %}
             <nav class="navigation" role="navigation">
                 <div id="mega-menu" class="navbar navbar-inverse navbar-fixed-top">

--- a/templates/helpscreen/base.html.twig
+++ b/templates/helpscreen/base.html.twig
@@ -1,4 +1,4 @@
-{% from 'macros.html.twig' import google_tag_manager %}
+{% from 'macros.html.twig' %}
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
@@ -21,7 +21,6 @@
         </script>
     </head>
     <body>
-        {{ google_tag_manager() }}
         <a name="Top" id="Top"></a>
         {% block content %}{% endblock %}
         <div id="footer-wrapper">


### PR DESCRIPTION
Based on this issue joomla/joomla-websites#1348, I'm removing the Google Tag Manager from the help site. GDPR requires us to either request consent before including this stuff or not include it at all. Since we couldn't get our shit together for over 2 years now, I'm starting this second attempt at removing this. AFAIK we aren't even using the data we collect here. Use a better, more privacy-friendly solution if you really think you need it.