### PR TITLE
Removing GTM and Pingdom remnants

### DIFF
--- a/templates/helpscreen/eol.html.twig
+++ b/templates/helpscreen/eol.html.twig
@@ -1,11 +1,10 @@
-{% from 'macros.html.twig' import full_page_head, google_tag_manager %}
+{% from 'macros.html.twig' import full_page_head %}
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
         {{ full_page_head() }}
     </head>
     <body>
-        {{ google_tag_manager() }}
         <div class="container">
             <div class="well text-center">
                 <img src="{{ asset('images/logo.png') }}" alt="Joomla! Logo">

--- a/templates/macros.html.twig
+++ b/templates/macros.html.twig
@@ -1,10 +1,3 @@
-{% macro google_tag_manager() %}
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NVGP9X" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-NVGP9X');</script>
-    <!-- End Google Tag Manager -->
-{% endmacro %}
-
 {% macro full_page_head() %}
     <title>Joomla! Help Site</title>
     <meta charset="utf-8">
@@ -23,15 +16,4 @@
     <script src="https://code.jquery.com/jquery-migrate-1.4.1.min.js"></script>
     <script src="{{ asset('/media/js/bootstrap.min.js') }}" type="text/javascript"></script>
     <!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
-    <script>
-    var _prum = [['id', '59300ad15992c776ad970068'],
-                 ['mark', 'firstbyte', (new Date()).getTime()]];
-    (function() {
-        var s = document.getElementsByTagName('script')[0]
-          , p = document.createElement('script');
-        p.async = 'async';
-        p.src = 'https://rum-static.pingdom.net/prum.min.js';
-        s.parentNode.insertBefore(p, s);
-    })();
-    </script>
 {% endmacro %}


### PR DESCRIPTION
This removes the GTM macro and all its remaining calls, as well as the Pingdom code from the header macro.